### PR TITLE
Use spacemacs|add-company-backends instead of deprecated functions

### DIFF
--- a/lean/config.el
+++ b/lean/config.el
@@ -1,2 +1,0 @@
-
-(spacemacs|defvar-company-backends company-lean)

--- a/lean/packages.el
+++ b/lean/packages.el
@@ -4,7 +4,7 @@
 
 
 (defun lean/post-init-company ()
-  (spacemacs|add-company-hook company-lean)
+  (spacemacs|add-company-backends :backends company-lean :modes lean-mode)
  )
 
 (defun lean/post-init-lean-mode ()

--- a/lean/packages.el
+++ b/lean/packages.el
@@ -1,6 +1,7 @@
 (setq lean-packages '(company
                       lean-mode
-                      company-lean))
+                      company-lean
+                      smartparens))
 
 
 (defun lean/post-init-company ()
@@ -35,11 +36,6 @@
   )
   (add-to-list 'spacemacs-indent-sensitive-modes 'lean-mode)
   (spacemacs|define-jump-handlers lean-mode (lean-find-definition :async t))
-  (sp-local-pair 'lean-mode "/-" "-/")
-  (sp-local-pair 'lean-mode "`'" nil :actions :rem)
-  (sp-local-pair 'lean-mode "⟨" "⟩")
-  (sp-local-pair 'lean-mode "«" "»")
-
 )
 
 (defun lean/init-company-lean ()
@@ -48,3 +44,12 @@
     :mode "\\.lean\\'"
     )
   )
+
+(defun lean/pre-init-smartparens ()
+  (spacemacs|use-package-add-hook smartparens
+    :post-config
+    (progn
+      (sp-local-pair 'lean-mode "/-" "-/")
+      (sp-local-pair 'lean-mode "`'" nil :actions :rem)
+      (sp-local-pair 'lean-mode "⟨" "⟩")
+      (sp-local-pair 'lean-mode "«" "»"))))


### PR DESCRIPTION
As `spacemacs|defvar-company-backends` has been deprecated and actually been cleaned up in develop, we need to follow the newer way.
See https://github.com/syl20bnr/spacemacs/commit/74fdbb6795018a93a665fa2c417589cd4cbd51fc for details.